### PR TITLE
add IndieAuth to list of examples

### DIFF
--- a/cfp.md
+++ b/cfp.md
@@ -38,7 +38,7 @@ Topics will include:
 > * Strong Authentication: FIDO, WebAuthn, IFAA, DIDAuth, OpenID Connect
 > * Strong Identity: ISO 29003, Entity Attestation Token (EAT)
 > * Decentralized Identity (DID): Blockchain / Distributed Ledger Technologies, Verifiable Credentials
-> * Federation: OpenID Connect, SAML, DID
+> * Federation: OpenID Connect, SAML, IndieAuth, DID
 > * Credentials: Verifiable Credentials, JWT, JSON-LD, Entity Attestation Token (EAT)
 > * Requirements: Ease of Use, Accessibility, Internationalization, Security, Privacy
 


### PR DESCRIPTION
IndieAuth is a W3C Note published by the Social Web Working Group at https://www.w3.org/TR/indieauth/

The latest version can be found at https://indieauth.spec.indieweb.org/

For more background on IndieAuth and its relationship to OAuth 2.0, please read [OAuth for the Open Web](https://aaronparecki.com/2018/07/07/7/oauth-for-the-open-web).