### PR TITLE
Add IEEE 2410 to list of strong authentication standards to be discussed

### DIFF
--- a/cfp.md
+++ b/cfp.md
@@ -35,7 +35,7 @@ This workshop, as other W3C meetings, operates under its [Code of Ethics and Pro
 
 Topics will include:
 
-> * Strong Authentication: FIDO, WebAuthn, IFAA, DIDAuth, OpenID Connect
+> * Strong Authentication: FIDO, WebAuthn, IFAA, DIDAuth, OpenID Connect, IEEE 2410
 > * Strong Identity: ISO 29003, Entity Attestation Token (EAT)
 > * Decentralized Identity (DID): Blockchain / Distributed Ledger Technologies, Verifiable Credentials
 > * Federation: OpenID Connect, SAML, DID


### PR DESCRIPTION
Compatible with FIDO UAF and WebAuthN, IEEE 2410 allows for mobile and server storage and match of biometric credentials paired with a generated key pair.  IEEE 2410 is now in its 2nd generation (IEEE 2410-2017).